### PR TITLE
Add different emission mask mode

### DIFF
--- a/Shaders/Eye/EyePlus.shader
+++ b/Shaders/Eye/EyePlus.shader
@@ -18,6 +18,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_CustomAmbient("Custom Ambient", Color) = (0.666666666, 0.666666666, 0.666666666, 1)
 		[MaterialToggle] _UseRampForLights ("Use Ramp For Light", Float) = 1
 		_DisablePointLights ("Disable Point Lights", Range(0,1)) = 0.0

--- a/Shaders/Eye/EyePlusTess.shader
+++ b/Shaders/Eye/EyePlusTess.shader
@@ -18,6 +18,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_CustomAmbient("Custom Ambient", Color) = (0.666666666, 0.666666666, 0.666666666, 1)
 		[MaterialToggle] _UseRampForLights ("Use Ramp For Light", Float) = 1
 		_DisablePointLights ("Disable Point Lights", Range(0,1)) = 0.0

--- a/Shaders/Eye/EyeWPlus.shader
+++ b/Shaders/Eye/EyeWPlus.shader
@@ -9,6 +9,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_CustomAmbient("Custom Ambient", Color) = (0.666666666, 0.666666666, 0.666666666, 1)
 		[MaterialToggle] _UseRampForLights ("Use Ramp For Light", Float) = 1
 

--- a/Shaders/Eye/EyeWPlusTess.shader
+++ b/Shaders/Eye/EyeWPlusTess.shader
@@ -9,6 +9,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_CustomAmbient("Custom Ambient", Color) = (0.666666666, 0.666666666, 0.666666666, 1)
 		[MaterialToggle] _UseRampForLights ("Use Ramp For Light", Float) = 1
 

--- a/Shaders/Eye/KKPEyePlusFrag.cginc
+++ b/Shaders/Eye/KKPEyePlusFrag.cginc
@@ -110,12 +110,9 @@ fixed4 frag (Varyings i) : SV_Target {
 	emissionUV = emissionUV + float2(dot(i.tanWS, viewDir), dot(i.bitanWS, viewDir)) * -0.06 * _ExpressionDepth;
 	emissionUV = emissionUV * _MainTex_ST.xy + _MainTex_ST.zw;
 	emissionUV = emissionUV * _EmissionMask_ST.xy + _EmissionMask_ST.zw;
-	
-	float4 emissionMask = SAMPLE_TEX2D(_EmissionMask, emissionUV);
-	float3 emissionCol =  _EmissionColor.rgb * _EmissionIntensity * emissionMask.rgb;
-	float4 emission = float4(emissionCol, emissionMask.a * _EmissionColor.a * iris.a);
-	
-	finalCol = max(finalCol, 1E-06) + emission.rgb * emission.a;
+
+	float4 emission = GetEmission(emissionUV);
+	finalCol = max(CombineEmission(finalCol, emission), 1E-06);
 	
 	return float4(max(finalCol, 1E-06), alpha);
 }

--- a/Shaders/Eye/KKPEyeWPlusFrag.cginc
+++ b/Shaders/Eye/KKPEyeWPlusFrag.cginc
@@ -79,7 +79,7 @@ fixed4 frag (Varyings i) : SV_Target
 
 	// Overlay emission over everything
 	float4 emission = GetEmission(i.uv0);
-	finalCol = finalCol * (1 - emission.a) + (emission.a * emission.rgb);
+	finalCol = CombineEmission(finalCol, emission);
 	
 	return float4(max(finalCol, 1E-06), alpha);
 }

--- a/Shaders/Hair/HairFrontPlus.shader
+++ b/Shaders/Hair/HairFrontPlus.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairFrontPlusReflect.shader
+++ b/Shaders/Hair/HairFrontPlusReflect.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairFrontPlusTess.shader
+++ b/Shaders/Hair/HairFrontPlusTess.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairFrontPlusTessReflect.shader
+++ b/Shaders/Hair/HairFrontPlusTessReflect.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairPlus.shader
+++ b/Shaders/Hair/HairPlus.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairPlusReflect.shader
+++ b/Shaders/Hair/HairPlusReflect.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairPlusTess.shader
+++ b/Shaders/Hair/HairPlusTess.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/HairPlusTessReflect.shader
+++ b/Shaders/Hair/HairPlusTessReflect.shader
@@ -35,6 +35,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		_LineWidthS ("LineWidthS", Float) = 1
 		[Enum(Off,0,On,1)]_OutlineOn ("Outline On", Float) = 1.0
 		[Enum(Off,0,On,1)]_SpecularHeightInvert ("Specular Height Invert", Float) = 0

--- a/Shaders/Hair/KKPHairVertFrag.cginc
+++ b/Shaders/Hair/KKPHairVertFrag.cginc
@@ -249,7 +249,7 @@ fixed4 frag (Varyings i, int frontFace : VFACE) : SV_Target
 
 	//Overlay Emission over everything
 	float4 emission = GetEmission(i.uv0);
-	finalDiffuse = finalDiffuse * (1 - emission.a) +  (emission.a * emission.rgb);
+	finalDiffuse = CombineEmission(finalDiffuse, emission);
 
 	return float4(max(finalDiffuse, 1E-06), alpha);
 }

--- a/Shaders/Item/KKPItemFrag.cginc
+++ b/Shaders/Item/KKPItemFrag.cginc
@@ -292,7 +292,7 @@ fixed4 frag (Varyings i, int faceDir : VFACE) : SV_Target{
 	finalDiffuse = lerp(finalDiffuse, kkpFresCol, _KKPRimColor.a * kkpFres * rimPlace * (1 - _KKPRimAsDiffuse));
 
 	float4 emission = GetEmission(i.uv0);
-	finalDiffuse = finalDiffuse * (1 - emission.a) + (emission.a*emission.rgb);
+	finalDiffuse = CombineEmission(finalDiffuse, emission);
 
 	float alpha = 1;
 	

--- a/Shaders/Item/KKPItemItemFrag.cginc
+++ b/Shaders/Item/KKPItemItemFrag.cginc
@@ -287,7 +287,7 @@ fixed4 frag (Varyings i, int faceDir : VFACE) : SV_Target {
 	finalDiffuse = lerp(finalDiffuse, kkpFresCol, _KKPRimColor.a * kkpFres * rimPlace * (1 - _KKPRimAsDiffuse));
 
 	float4 emission = GetEmission(i.uv0);
-	finalDiffuse = finalDiffuse * (1 - emission.a) + (emission.a*emission.rgb);
+	finalDiffuse = CombineEmission(finalDiffuse, emission);
 	
 	float alpha = 1;
 	#ifdef ALPHA_SHADER

--- a/Shaders/Item/MainAlphaPlus.shader
+++ b/Shaders/Item/MainAlphaPlus.shader
@@ -12,6 +12,7 @@ Shader "xukmi/MainAlphaPlus"
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,1)

--- a/Shaders/Item/MainAlphaPlusTess.shader
+++ b/Shaders/Item/MainAlphaPlusTess.shader
@@ -12,6 +12,7 @@ Shader "xukmi/MainAlphaPlusTess"
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,1)

--- a/Shaders/Item/MainItemAlphaPlus.shader
+++ b/Shaders/Item/MainItemAlphaPlus.shader
@@ -11,6 +11,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Color) = (1,1,1,1)

--- a/Shaders/Item/MainItemAlphaPlusTess.shader
+++ b/Shaders/Item/MainItemAlphaPlusTess.shader
@@ -11,6 +11,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Color) = (1,1,1,1)

--- a/Shaders/Item/MainItemPlus.shader
+++ b/Shaders/Item/MainItemPlus.shader
@@ -11,6 +11,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Color) = (1,1,1,1)

--- a/Shaders/Item/MainItemPlusTess.shader
+++ b/Shaders/Item/MainItemPlusTess.shader
@@ -11,6 +11,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Color) = (1,1,1,1)

--- a/Shaders/Item/MainOpaquePlus.shader
+++ b/Shaders/Item/MainOpaquePlus.shader
@@ -12,6 +12,7 @@ Shader "xukmi/MainOpaquePlus"
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,1)

--- a/Shaders/Item/MainOpaquePlusTess.shader
+++ b/Shaders/Item/MainOpaquePlusTess.shader
@@ -12,6 +12,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Vector) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,1)

--- a/Shaders/KKPEmission.cginc
+++ b/Shaders/KKPEmission.cginc
@@ -5,12 +5,19 @@ DECLARE_TEX2D(_EmissionMask);
 float4 _EmissionMask_ST;
 float4 _EmissionColor;
 float _EmissionIntensity;
+float _EmissionMaskMode;
 
 float4 GetEmission(float2 uv){
 	float2 emissionUV = uv * _EmissionMask_ST.xy + _EmissionMask_ST.zw;
 	float4 emissionMask = SAMPLE_TEX2D(_EmissionMask, emissionUV);
 	float3 emissionCol = _EmissionColor.rgb * _EmissionIntensity * emissionMask.rgb;
 	return float4(emissionCol, emissionMask.a * _EmissionColor.a);
+}
+
+float3 CombineEmission(float3 col, float4 emission){
+	float3 maskedEmission = col + lerp(0, col, emission) * emission.a;
+	float3 overlayedEmission = col * (1 - emission.a) + (emission.a*emission.rgb);
+	return maskedEmission * _EmissionMaskMode + overlayedEmission * (1 - _EmissionMaskMode);
 }
 
 #endif

--- a/Shaders/Skin/KKPSkinFrag.cginc
+++ b/Shaders/Skin/KKPSkinFrag.cginc
@@ -206,7 +206,7 @@ fixed4 frag (Varyings i, int frontFace : VFACE) : SV_Target
 
 	//Overlay Emission over everything
 	float4 emission = GetEmission(i.uv0);
-	finalCol = finalCol * (1 - emission.a) + (emission.a*emission.rgb);
+	finalCol = CombineEmission(finalCol, emission);
 
 	return float4(max(finalCol, 1E-06), 1); 
 }

--- a/Shaders/Skin/SkinPlus.shader
+++ b/Shaders/Skin/SkinPlus.shader
@@ -23,6 +23,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Color) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,0)

--- a/Shaders/Skin/SkinPlusReflect.shader
+++ b/Shaders/Skin/SkinPlusReflect.shader
@@ -23,6 +23,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Color) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,0)

--- a/Shaders/Skin/SkinPlusTess.shader
+++ b/Shaders/Skin/SkinPlusTess.shader
@@ -23,6 +23,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Color) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,0)

--- a/Shaders/Skin/SkinPlusTessReflect.shader
+++ b/Shaders/Skin/SkinPlusTessReflect.shader
@@ -23,6 +23,7 @@
 		_EmissionMask ("Emission Mask", 2D) = "black" {}
 		[Gamma]_EmissionColor("Emission Color", Color) = (1, 1, 1, 1)
 		_EmissionIntensity("Emission Intensity", Float) = 1
+		_EmissionMaskMode("Emission Mask Mode", Float) = 0
 		[Gamma]_ShadowColor ("Shadow Color", Color) = (0.628,0.628,0.628,1)
 		_ShadowHSV ("Shadow HSV", Vector) = (0, 0, 0, 0)
 		[Gamma]_SpecularColor ("Specular Color", Vector) = (1,1,1,0)

--- a/manifest.xml
+++ b/manifest.xml
@@ -8,11 +8,11 @@
   <website>https://www.pixiv.net/en/users/66587336</website>
   <MaterialEditor>
     <Shader Name="xukmi/SkinPlus" AssetBundle="chara/xukmi/shaders/vanillaplus.unity3d" Asset="a_SkinPlus">
-	  <Property Name="ColMask" Type="Texture" />
-	  <Property Name="Col0" Type="Color" />
-	  <Property Name="Col1" Type="Color" />
-	  <Property Name="Col2" Type="Color" />
-	  <Property Name="Col3" Type="Color" />
+      <Property Name="ColMask" Type="Texture" />
+      <Property Name="Col0" Type="Color" />
+      <Property Name="Col1" Type="Color" />
+      <Property Name="Col2" Type="Color" />
+      <Property Name="Col3" Type="Color" />
       <Property Name="AlphaMask" Type="Texture" />
       <Property Name="DetailMask" Type="Texture" />
       <Property Name="LineMask" Type="Texture" />
@@ -29,6 +29,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="overcolor1" Type="Color" />
       <Property Name="overcolor2" Type="Color" />
@@ -82,12 +83,12 @@
       <Property Name="ShadowHSV" Type="Color" />
     </Shader>
     <Shader Name="xukmi/SkinPlusReflect" AssetBundle="chara/xukmi/shaders/vanillaplus.unity3d" Asset="a_SkinPlusReflect">
-	  <Property Name="ColMask" Type="Texture" />
-	  <Property Name="Col0" Type="Color" />
-	  <Property Name="Col1" Type="Color" />
-	  <Property Name="Col2" Type="Color" />
-	  <Property Name="Col3" Type="Color" />
-	  <Property Name="AlphaMask" Type="Texture" />
+      <Property Name="ColMask" Type="Texture" />
+      <Property Name="Col0" Type="Color" />
+      <Property Name="Col1" Type="Color" />
+      <Property Name="Col2" Type="Color" />
+      <Property Name="Col3" Type="Color" />
+      <Property Name="AlphaMask" Type="Texture" />
       <Property Name="DetailMask" Type="Texture" />
       <Property Name="LineMask" Type="Texture" />
       <Property Name="liquidmask" Type="Texture" />
@@ -103,6 +104,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="overcolor1" Type="Color" />
       <Property Name="overcolor2" Type="Color" />
@@ -169,12 +171,12 @@
       <Property Name="ShadowHSV" Type="Color" />
     </Shader>
     <Shader Name="xukmi/SkinPlusTess" AssetBundle="chara/xukmi/shaders/vanillaplus.unity3d" Asset="a_SkinPlusTess">
-	  <Property Name="ColMask" Type="Texture" />
-	  <Property Name="Col0" Type="Color" />
-	  <Property Name="Col1" Type="Color" />
-	  <Property Name="Col2" Type="Color" />
-	  <Property Name="Col3" Type="Color" />
-	  <Property Name="AlphaMask" Type="Texture" />
+      <Property Name="ColMask" Type="Texture" />
+      <Property Name="Col0" Type="Color" />
+      <Property Name="Col1" Type="Color" />
+      <Property Name="Col2" Type="Color" />
+      <Property Name="Col3" Type="Color" />
+      <Property Name="AlphaMask" Type="Texture" />
       <Property Name="DetailMask" Type="Texture" />
       <Property Name="LineMask" Type="Texture" />
       <Property Name="liquidmask" Type="Texture" />
@@ -190,6 +192,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="overcolor1" Type="Color" />
       <Property Name="overcolor2" Type="Color" />
@@ -254,12 +257,12 @@
       <Property Name="ShadowHSV" Type="Color" />
     </Shader>
     <Shader Name="xukmi/SkinPlusTessReflect" AssetBundle="chara/xukmi/shaders/vanillaplus.unity3d" Asset="a_SkinPlusTessReflect">
-	  <Property Name="ColMask" Type="Texture" />
-	  <Property Name="Col0" Type="Color" />
-	  <Property Name="Col1" Type="Color" />
-	  <Property Name="Col2" Type="Color" />
-	  <Property Name="Col3" Type="Color" />
-	  <Property Name="AlphaMask" Type="Texture" />
+      <Property Name="ColMask" Type="Texture" />
+      <Property Name="Col0" Type="Color" />
+      <Property Name="Col1" Type="Color" />
+      <Property Name="Col2" Type="Color" />
+      <Property Name="Col3" Type="Color" />
+      <Property Name="AlphaMask" Type="Texture" />
       <Property Name="DetailMask" Type="Texture" />
       <Property Name="LineMask" Type="Texture" />
       <Property Name="liquidmask" Type="Texture" />
@@ -275,6 +278,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="overcolor1" Type="Color" />
       <Property Name="overcolor2" Type="Color" />
@@ -386,6 +390,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -437,6 +442,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -500,6 +506,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -564,6 +571,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -639,6 +647,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -700,6 +709,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -773,6 +783,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -838,6 +849,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="OutlineOn" Type="Float" Range="0, 1" />
       <Property Name="SpecularHeightInvert" Type="Float" Range="0, 1" />
       <Property Name="LineWidthS" Type="Float" Range="0, 1" />
@@ -891,6 +903,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ExpressionSize" Type="Float" Range="0, 1" />
       <Property Name="ExpressionDepth" Type="Float" Range="0, 2" />
       <Property Name="CustomAmbient" Type="Color" />
@@ -925,6 +938,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ExpressionSize" Type="Float" Range="0, 1" />
       <Property Name="ExpressionDepth" Type="Float" Range="0, 2" />
       <Property Name="CustomAmbient" Type="Color" />
@@ -966,6 +980,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="DisablePointLights" Type="Float" Range="0, 1" />
       <Property Name="DisableShadowedMatcap" Type="Float" Range="0, 1" />
       <Property Name="ReflectMap" Type="Texture" />
@@ -992,6 +1007,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="DisablePointLights" Type="Float" Range="0, 1" />
       <Property Name="DisableShadowedMatcap" Type="Float" Range="0, 1" />
       <Property Name="ReflectMap" Type="Texture" />
@@ -1033,6 +1049,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
@@ -1105,6 +1122,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
@@ -1190,6 +1208,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
@@ -1264,6 +1283,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="LiquidTiling" Type="Color" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
@@ -1348,6 +1368,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1413,6 +1434,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1491,6 +1513,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1558,6 +1581,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1638,6 +1662,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1716,6 +1741,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1807,6 +1833,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />
@@ -1885,6 +1912,7 @@
       <Property Name="EmissionMask" Type="Texture" />
       <Property Name="EmissionColor" Type="Color" />
       <Property Name="EmissionIntensity" Type="Float" />
+      <Property Name="EmissionMaskMode" Type="Float" />
       <Property Name="ShadowColor" Type="Color" />
       <Property Name="SpecularColor" Type="Color" />
       <Property Name="Color" Type="Color" />


### PR DESCRIPTION
Currently the emission mask doesn't really mask, and actually just overlays the emission on top. By setting the new `EmissionMaskMode` slider to 1, it will actually function as a mask and make the underlying colour emissive instead.